### PR TITLE
Fix GoReleaser configuration and workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write  # Needed for creating releases and uploading assets
+
 jobs:
   goreleaser:
     name: Release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: dotme
 
 before:


### PR DESCRIPTION
This PR fixes the GoReleaser configuration by:

1. Adding `version: 2` to the `.goreleaser.yaml` file to match the required format
2. Adding explicit `contents: write` permission to the release workflow to fix the GitHub API 403 error

These changes will allow the v0.2.0 release process to complete successfully.