### PR TITLE
Update CHANGELOG.md for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.2.0] - 2025-04-15
 ### Added
 - Repository alias functionality:
   - Save repositories with custom aliases for quick access (`-s, --save` flag)


### PR DESCRIPTION
This PR updates the CHANGELOG.md file to prepare for the v0.2.0 release. It converts the 'Unreleased' section to the new v0.2.0 release with today's date (April 15, 2025).